### PR TITLE
fix(visualization-server): Convert Visualization Server image into a build config

### DIFF
--- a/backend/Dockerfile.visualization
+++ b/backend/Dockerfile.visualization
@@ -20,14 +20,12 @@
 # This image should be in sync with image in backend/src/apiserver/visualization/update_requirements.sh.
 FROM tensorflow/tensorflow:2.5.1
 
-RUN apt-get update \
-  && apt-get install -y wget curl tar openssl
+USER root
 
-RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
-RUN mkdir -p /usr/local/gcloud
-RUN tar -C /usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz
-RUN /usr/local/gcloud/google-cloud-sdk/install.sh
-ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+RUN dnf update -y && \
+    dnf install -y wget curl tar openssl && \
+    dnf clean -y all && \
+    rm -rf /var/cache/dnf
 
 WORKDIR /src
 
@@ -37,4 +35,16 @@ RUN python3 -m pip install --upgrade pip && python3 -m pip install -r requiremen
 
 COPY backend/src/apiserver/visualization /src
 
+USER 1001
+
 ENTRYPOINT [ "python3", "server.py" ]
+
+LABEL com.redhat.component="odh-ml-pipelines-visualizationserver-container" \
+      name="managed-open-data-hub/odh-ml-pipelines-visualizationserver-container-rhel8" \
+      version="${CI_CONTAINER_VERSION}" \
+      release="${CI_CONTAINER_RELEASE}" \
+      summary="odh-ml-pipelines-visualizationserver" \
+      io.openshift.expose-services="" \
+      io.k8s.display-name="odh-ml-pipelines-visualizationserver" \
+      maintainer="['managed-open-data-hub@redhat.com']" \
+      description="odh-ml-pipelines-visualizationserver"

--- a/backend/src/apiserver/visualization/requirements.txt
+++ b/backend/src/apiserver/visualization/requirements.txt
@@ -74,8 +74,7 @@ jsonschema==3.2.0         # via nbformat
 jupyter-client==5.3.5     # via -r -, ipykernel, notebook
 jupyter-core==4.9.1       # via jupyter-client, nbconvert, nbformat, notebook
 jupyterlab-widgets==1.0.2 # via ipywidgets
-keras==2.6.0              # via tensorflow
-keras-preprocessing==1.1.2  # via tensorflow
+keras==2.6.0
 libcst==0.3.23            # via google-cloud-bigquery-storage
 markdown==3.3.6           # via tensorboard
 markupsafe==2.0.1         # via jinja2
@@ -122,15 +121,6 @@ scikit_learn==0.21.2      # via -r -
 scipy==1.5.4              # via scikit-learn, tensorflow-model-analysis
 send2trash==1.8.0         # via notebook
 six==1.15.0               # via absl-py, astunparse, bleach, bokeh, fasteners, google-api-core, google-api-python-client, google-apitools, google-auth, google-auth-httplib2, google-cloud-core, google-pasta, google-resumable-media, grpcio, hdfs, jsonschema, keras-preprocessing, oauth2client, python-dateutil, tensorflow, tensorflow-data-validation, tensorflow-model-analysis, traitlets
-tensorboard-data-server==0.6.1  # via tensorboard
-tensorboard-plugin-wit==1.8.0  # via tensorboard
-tensorboard==2.7.0        # via tensorflow
-tensorflow-data-validation==1.2.0  # via -r -
-tensorflow-estimator==2.5.0  # via tensorflow
-tensorflow-metadata==1.2.0  # via -r -, tensorflow-data-validation, tensorflow-model-analysis, tfx-bsl
-tensorflow-model-analysis==0.33.0  # via -r -
-tensorflow-serving-api==2.5.1  # via -r -, tfx-bsl
-tensorflow==2.5.1         # via -r -, tensorflow-data-validation, tensorflow-model-analysis, tensorflow-serving-api, tfx-bsl
 termcolor==1.1.0          # via tensorflow
 terminado==0.12.1         # via notebook
 testpath==0.5.0           # via nbconvert

--- a/manifests/opendatahub/base/buildconfigs/vizualization-server.yaml
+++ b/manifests/opendatahub/base/buildconfigs/vizualization-server.yaml
@@ -1,0 +1,35 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: visualization-server
+spec:
+  output:
+    to: 
+      kind: ImageStreamTag
+      name: 'visualization-server:1.3.1'
+  resources:
+    limits:
+      cpu: "4"
+      memory: 8Gi
+    requests:
+      cpu: "4"
+      memory: 8Gi
+  completionDeadlineSeconds: 1800
+  successfulBuildsHistoryLimit: 1
+  failedBuildsHistoryLimit: 1
+  strategy:
+    type: Docker
+    dockerStrategy:
+      from:
+        kind: ImageStreamTag
+        name: 'tensorflow:py3.8-cuda-11.4.2-2'
+      dockerfilePath: backend/Dockerfile.visualization
+  postCommit: {}
+  source:
+    type: Git
+    git:
+      uri: "https://github.com/red-hat-data-services/ml-pipelines"
+      ref: master
+  triggers:
+    - type: ImageChange
+      imageChange: {}

--- a/manifests/opendatahub/base/deployments/ml-pipeline-visualizationserver.yaml
+++ b/manifests/opendatahub/base/deployments/ml-pipeline-visualizationserver.yaml
@@ -1,6 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    alpha.image.policy.openshift.io/resolve-names: 'visualization-server:1.3.1'
+    image.openshift.io/triggers: >-
+      [{"from":{"kind":"ImageStreamTag","name":"visualization-server:1.3.1"},"fieldPath":"spec.template.spec.containers[?(@.name==\"ml-pipeline-visualizationserver\")].image"}]
   labels:
     app: ml-pipeline-visualizationserver
     application-crd-id: kubeflow-pipelines
@@ -18,9 +22,26 @@ spec:
         app: ml-pipeline-visualizationserver
         application-crd-id: kubeflow-pipelines
     spec:
+      initContainers:
+        - name: image-checker
+          image: 'quay.io/modh/odh-deployer:v1.15.0-10-rhods'
+          command:
+            - sh
+            - '-c'
+            - |
+              while :
+              do
+                TEST=$(oc get istag visualization-server:1.3.1 | wc -l)
+
+                if [[ $TEST -gt 0 ]]; then
+                  break
+                fi
+                echo "Image is not built yet, please wait..."
+                sleep 30
+              done
       containers:
-        - image: visualization-server
-          imagePullPolicy: IfNotPresent
+        - image: visualization-server:1.3.1
+          imagePullPolicy: Always
           name: ml-pipeline-visualizationserver
           ports:
             - containerPort: 8888

--- a/manifests/opendatahub/base/imagestreams/visualization-server.yaml
+++ b/manifests/opendatahub/base/imagestreams/visualization-server.yaml
@@ -1,0 +1,11 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: "visualization-server"
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - name: "1.3.1"
+    referencePolicy:
+      type: Local

--- a/manifests/opendatahub/base/kustomization.yaml
+++ b/manifests/opendatahub/base/kustomization.yaml
@@ -3,6 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  # Build Configs
+  - ./buildconfigs/vizualization-server.yaml
+
   # CustomResourceDefinitions
   - ./customresourcedefinitions/viewers.yaml
   - ./customresourcedefinitions/scheduledworkflows.yaml
@@ -20,6 +23,7 @@ resources:
   - ./rolebindings/ml-pipeline-viewer-crd-binding.yaml
   - ./rolebindings/ml-pipeline.yaml
   - ./rolebindings/pipeline-runner-binding.yaml
+  - ./rolebindings/ml-pipeline-visualizationserver.yaml
 
   # ServiceAccounts
   - ./serviceaccounts/kubeflow-pipelines-container-builder.yaml
@@ -41,6 +45,9 @@ resources:
   - ./deployments/ml-pipeline-viewer-crd.yaml
   - ./deployments/ml-pipeline-visualizationserver.yaml
   - ./deployments/ml-pipeline.yaml
+
+  # Image Streams
+  - ./imagestreams/visualization-server.yaml
 
   # Services
   - ./services/ml-pipeline-visualizationserver.yaml
@@ -104,9 +111,6 @@ images:
     newTag: 1.1.0
   - name: viewer-crd-controller
     newName: gcr.io/ml-pipeline/viewer-crd-controller
-    newTag: 1.7.0
-  - name: visualization-server
-    newName: gcr.io/ml-pipeline/visualization-server
     newTag: 1.7.0
   - name: api-server
     newName: quay.io/internaldatahub/api-server

--- a/manifests/opendatahub/base/rolebindings/ml-pipeline-visualizationserver.yaml
+++ b/manifests/opendatahub/base/rolebindings/ml-pipeline-visualizationserver.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ml-pipeline-visualizationserver
+subjects:
+  - kind: ServiceAccount
+    name: ml-pipeline-visualizationserver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ml-pipeline

--- a/manifests/opendatahub/base/roles/ml-pipeline.yaml
+++ b/manifests/opendatahub/base/roles/ml-pipeline.yaml
@@ -78,3 +78,9 @@ rules:
       - update
       - patch
       - delete
+  - apiGroups:
+      - image.openshift.io
+    resources:
+      - imagestreamtags
+    verbs:
+      - get

--- a/manifests/opendatahub/overlays/ml-pipeline-ui/rolebindings/auth-delegator.yaml
+++ b/manifests/opendatahub/overlays/ml-pipeline-ui/rolebindings/auth-delegator.yaml
@@ -8,4 +8,5 @@ roleRef:
   name: system:auth-delegator
 subjects:
   - kind: ServiceAccount
+    namespace: $(namespace)
     name: ml-pipeline-ui


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
RHODS-4992

**Description of your changes:**
Convert Visualization Server image into a build config, using the pre-build tensorflow notebook images as base for building viz server.

**Environment tested:**

* Python Version (use `python --version`): 3.10
* Tekton Version (use `tkn version`): 0.21.0
* Kubernetes Version (use `kubectl version`): 1.6.0
* OS (e.g. from `/etc/os-release`): Fedora 35

**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
